### PR TITLE
Fix for non-interactive mode when there is no terminal

### DIFF
--- a/runebuf.go
+++ b/runebuf.go
@@ -472,9 +472,12 @@ func (r *RuneBuffer) SetOffset(offset string) {
 }
 
 func (r *RuneBuffer) Print() {
+	if !r.interactive {
+		return
+	}
 	r.Lock()
+	defer r.Unlock()
 	r.print()
-	r.Unlock()
 }
 
 func (r *RuneBuffer) print() {


### PR DESCRIPTION
Originally the code called Refresh(nil). This had handling for
non-interactive mode where the code would return without printing
a prompt. When issue169 was initially fixed, the interactive
part of this was mistakenly dropped. This puts the interactive
check back into the flow.